### PR TITLE
fix: set version for yaml conversion as well

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         echo '''${{ inputs.config }}''' > config.yml
       shell: bash
       
-    - uses: fabasoad/data-format-converter-action@main
+    - uses: fabasoad/data-format-converter-action@v0.3.0
       id: yaml-to-json
       with:
         input: "config.yml"


### PR DESCRIPTION
## what
- additionally version lock another data conversion action

## why
- action is failing due to recent changes

## references
- see prior PR #17 
