### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -45,7 +45,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         
       - uses: ./
         id: current
@@ -80,31 +80,31 @@ jobs:
               service-config-ssm-path: service/app/config/custom/app-ns
               foo: bar
             
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.current.outputs.namespace }}"
           expected: '${{ matrix.expected-namespace }}'
 
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         if: ${{ matrix.expected-cluster-role }}
         with:
           actual: "${{ steps.current.outputs.role }}"
           expected: '${{ matrix.expected-cluster-role }}'
           
       - name: Environment info
-        uses: cloudposse/github-action-yaml-config-query@v1.0.0
+        uses: cloudposse/github-action-yaml-config-query@8178e0c0d186f53de40f6bcf8e039f1e6a9aefc5 # v1.0.1
         id: result
         with:
           query: .
           config: ${{ steps.current.outputs.environment-config }}
 
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         if: ${{ matrix.expected-foo }}
         with:
           actual: "${{ steps.result.outputs.foo }}"
           expected: '${{ matrix.expected-foo }}'
           
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         if: ${{ matrix.expected-service-config-ssm-path }}
         with:
           actual: "${{ steps.result.outputs.service-config-ssm-path }}"

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
   using: "composite"
   steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
     - run: |
         echo '''${{ inputs.config }}''' > config.yml
@@ -63,7 +63,7 @@ runs:
     
     - name: Evaluate Config
       id: parse-config
-      uses: actions/github-script@v6
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           let data = JSON.parse(`${{ steps.yaml-to-json.outputs.output }}`);
@@ -127,7 +127,7 @@ runs:
 
     - name: Merge Substitutions
       id: merge-config
-      uses: actions/github-script@v6
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           let data = JSON.parse(`${{ steps.parse-config.outputs.stripped-config }}`);
@@ -148,7 +148,7 @@ runs:
         to: "yaml"
         
     - name: Environment info
-      uses: cloudposse/github-action-yaml-config-query@v1.0.0
+      uses: cloudposse/github-action-yaml-config-query@8178e0c0d186f53de40f6bcf8e039f1e6a9aefc5 # v1.0.1
       id: result
       with:
         query: .


### PR DESCRIPTION
## what

* Bump GitHub Actions references in the workflows to versions running on the Node 24 runtime,
  SHA-pinned with precise version comments:
  * `actions/checkout@v3` → `@3d3c42e5...` `# v7.0.1`
  * `actions/github-script@v6` → `@3a2844b7...` `# v9.0.0`
  * `nick-fields/assert-action@v1` → `@0efd6166...` `# v4.0.1`
  * `cloudposse/github-action-yaml-config-query@v1.0.0` → `@8178e0c0...` `# v1.0.1`

## why

* GitHub is deprecating the Node 20 runtime; affected workflows emit a deprecation warning and
  are already being force-migrated to Node 24
* SHA pinning with a verified tag comment makes the upgrade deliberate and supply-chain-safe,
  matching the org's direction in cloudposse/.github#261
* Every pinned SHA was verified against its upstream tag

Supersedes #28
Supersedes #29
Supersedes #26
Supersedes #25

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
